### PR TITLE
fix(.xinitrc): Replace script process with window manager

### DIFF
--- a/x/.xinitrc
+++ b/x/.xinitrc
@@ -1,1 +1,1 @@
-dwm
+exec dwm


### PR DESCRIPTION
Using the `exec` command replaces the script process with the window manager which ensures that the user is logged out when the X server exits, crashes or is killed by an attacker.